### PR TITLE
Add keepOriginalFilename functionality to retain the uploaded filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ class Post extends Resource
                     ->storeAs(function (Illuminate\Http\File $file) { // this is optional, use in case you need generate custom file names
                         return Str::random(20) . '.' . $file->getExtension();
                     })
+                    ->keepOriginalFilename() // optional. Makes the file retain it's original filename. Filename can still be modified in storeAs()
 
         ];
 

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -28,6 +28,11 @@ class Filepond extends Field
     public $storeAsCallback;
 
     /**
+     * @var bool
+     */
+    private $keepOriginalFilename = false;
+
+    /**
      * @var string
      */
     private $disk = 'public';
@@ -177,6 +182,12 @@ class Filepond extends Field
 
     }
 
+    public function keepOriginalFilename(bool $value = true)
+    {
+        $this->keepOriginalFilename = $value;
+        return $this;
+    }
+
     public function updateRules($rules)
     {
 
@@ -305,13 +316,25 @@ class Filepond extends Field
 
     private function moveFile(File $file): string
     {
+        $metaPath = "{$file}_meta.json";
+        if (file_exists($metaPath)) {
+            $meta = json_decode(file_get_contents($metaPath));
+            unlink($metaPath);
+            if ($this->keepOriginalFilename && $meta->clientOriginalName) {
+                $pathInfo = pathinfo($file->getRealPath());
+                $file = $file->move('/tmp', $meta->clientOriginalName);
+                $file = new File($file->getRealPath());
+            }
+        }
 
         $name = $this->storeAsCallback ? call_user_func($this->storeAsCallback, $file) : $file->getBasename();
+
         $fullPath = $this->trimSlashes($this->directory ?? '') . '/' . $this->trimSlashes($name);
 
         $response = Storage::disk($this->disk)->put($fullPath, file_get_contents($file->getRealPath()));
 
         if ($response) {
+            unlink($file);
 
             return $this->trimSlashes($fullPath);
 

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -319,7 +319,6 @@ class Filepond extends Field
         $metaPath = "{$file}_meta.json";
         if (file_exists($metaPath)) {
             $meta = json_decode(file_get_contents($metaPath));
-            unlink($metaPath);
             if ($this->keepOriginalFilename && $meta->clientOriginalName) {
                 $pathInfo = pathinfo($file->getRealPath());
                 $file = $file->move('/tmp', $meta->clientOriginalName);
@@ -335,6 +334,7 @@ class Filepond extends Field
 
         if ($response) {
             unlink($file);
+            unlink($metaPath);
 
             return $this->trimSlashes($fullPath);
 

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -320,8 +320,12 @@ class Filepond extends Field
         if (file_exists($metaPath)) {
             $meta = json_decode(file_get_contents($metaPath));
             if ($this->keepOriginalFilename && $meta->clientOriginalName) {
-                $pathInfo = pathinfo($file->getRealPath());
-                $file = $file->move('/tmp', $meta->clientOriginalName);
+                $pathInfo = pathinfo($meta->clientOriginalName);
+                $suffix = '';
+                if (Storage::disk($this->disk)->exists($this->trimSlashes($this->directory ?? '') . '/' . $pathInfo['basename']) && !$this->storeAsCallback) {
+                    $suffix = '-' . mt_rand();
+                }
+                $file = $file->move('/tmp', "{$pathInfo['filename']}{$suffix}.{$pathInfo['extension']}");
                 $file = new File($file->getRealPath());
             }
         }


### PR DESCRIPTION
Add `keepOriginalFilename` flag that retains the original filename between the upload request and when the resource is actually saved.

Adds a meta json file which is associated with an upload to reconstruct the original path.

Relates to #10