### PR TITLE
Fix Filename Return when a path is set in Load Controller

### DIFF
--- a/src/Http/Controllers/LoadController.php
+++ b/src/Http/Controllers/LoadController.php
@@ -15,6 +15,6 @@ class LoadController
     {
         $data = Data::fromEncrypted($request->input('serverId'));
 
-        return Storage::disk($data->disk)->response($data->path, $data->filename);
+        return Storage::disk($data->disk)->response($data->path, urlencode($data->filename));
     }
 }


### PR DESCRIPTION
When setting a path to a file, the returned preview is returning a long string and not the filename and is causing an internal server error since the path contains "/" and is not URL encoded.

This also would be the fix for Error during load #46